### PR TITLE
fix variable name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
 
     if (requestCode == MY_SCAN_REQUEST_CODE) {
-        String resultStr;
+        String resultDisplayStr;
         if (data != null && data.hasExtra(CardIOActivity.EXTRA_SCAN_RESULT)) {
             CreditCard scanResult = data.getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT);
 


### PR DESCRIPTION
This fixes a small issue where the variable name being used in onActivityResult is different than the declared variable.
